### PR TITLE
Fix mDNS examples

### DIFF
--- a/Examples/08. mDNS/A-mDNS/A-mDNS.ino
+++ b/Examples/08. mDNS/A-mDNS/A-mDNS.ino
@@ -31,4 +31,6 @@ void setup() {
   Serial.println("mDNS responder started");
 }
 
-void loop() { }
+void loop() {
+  MDNS.update(); // Allow MDNS processing
+}

--- a/Examples/10. First web server/A-First_web_server/A-First_web_server.ino
+++ b/Examples/10. First web server/A-First_web_server/A-First_web_server.ino
@@ -46,6 +46,7 @@ void setup(void){
 }
 
 void loop(void){
+  MDNS.update();
   server.handleClient();                    // Listen for HTTP requests from clients
 }
 

--- a/Examples/10. First web server/B-Turning_on_and_off_an_LED/B-Turning_on_and_off_an_LED.ino
+++ b/Examples/10. First web server/B-Turning_on_and_off_an_LED/B-Turning_on_and_off_an_LED.ino
@@ -52,6 +52,7 @@ void setup(void){
 }
 
 void loop(void){
+  MDNS.update();
   server.handleClient();                    // Listen for HTTP requests from clients
 }
 

--- a/Examples/10. First web server/C-HTTP_POST/C-HTTP_POST.ino
+++ b/Examples/10. First web server/C-HTTP_POST/C-HTTP_POST.ino
@@ -48,6 +48,7 @@ void setup(void){
 }
 
 void loop(void){
+  MDNS.update();
   server.handleClient();                     // Listen for HTTP requests from clients
 }
 

--- a/Examples/11. SPIFFS/A-SPIFFS_File_server/A-SPIFFS_File_server.ino
+++ b/Examples/11. SPIFFS/A-SPIFFS_File_server/A-SPIFFS_File_server.ino
@@ -51,6 +51,7 @@ void setup() {
 }
 
 void loop(void) {
+  MDNS.update();
   server.handleClient();
 }
 

--- a/Examples/11. SPIFFS/B-Compressing_files/B-Compressing_files.ino
+++ b/Examples/11. SPIFFS/B-Compressing_files/B-Compressing_files.ino
@@ -51,6 +51,7 @@ void setup() {
 }
 
 void loop(void) {
+  MDNS.update();
   server.handleClient();
 }
 

--- a/Examples/12. Uploading files to the server/A-Upload_files_to_server/A-Upload_files_to_server.ino
+++ b/Examples/12. Uploading files to the server/A-Upload_files_to_server/A-Upload_files_to_server.ino
@@ -64,6 +64,7 @@ void setup() {
 }
 
 void loop() {
+  MDNS.update();
   server.handleClient();
 }
 

--- a/Examples/14. WebSocket/A-WebSocket_LED_control/A-WebSocket_LED_control.ino
+++ b/Examples/14. WebSocket/A-WebSocket_LED_control/A-WebSocket_LED_control.ino
@@ -58,12 +58,13 @@ unsigned long prevMillis = millis();
 int hue = 0;
 
 void loop() {
+  MDNS.update();
   webSocket.loop();                           // constantly check for websocket events
   server.handleClient();                      // run the server
   ArduinoOTA.handle();                        // listen for OTA events
 
   if(rainbow) {                               // if the rainbow effect is turned on
-    if(millis() > prevMillis + 32) {          
+    if(millis() > prevMillis + 32) {
       if(++hue == 360)                        // Cycle through the color wheel (increment by one degree every 32 ms)
         hue = 0;
       setHue(hue);                            // Set the RGB LED to the right color

--- a/Examples/16. Data logging/A-Temperature_logger/A-Temperature_logger.ino
+++ b/Examples/16. Data logging/A-Temperature_logger/A-Temperature_logger.ino
@@ -86,6 +86,8 @@ const unsigned long DS_delay = 750;         // Reading the temperature from the 
 uint32_t timeUNIX = 0;                      // The most recent timestamp received from the time server
 
 void loop() {
+  MDNS.update();
+
   unsigned long currentMillis = millis();
 
   if (currentMillis - prevNTP > intervalNTP) { // Request the time from the time server every hour


### PR DESCRIPTION
The current mDNS example, which uses only `MDNS.begin()`, did not work at all for me.

I looked at the ESP8266 mDNS examples (https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266mDNS) and they all have `MDNS.update()` in the loop - added in the latest commit in December 2018, so presumably this is a new change to the API.

Adding the update call fixed mDNS for me. For this PR I searched for all the files which contain `MDNS.begin()` and added `MDNS.update()` to them. The need for the update call in the main loop should probably also be mentioned in the chapter 8 text, but I'm not sure how exactly to add that to the PR so I'll leave that up to you :)

As a note, when my main loop was 2.05 seconds long I got mDNS resolution timeouts on my computer, even though I was calling `MDNS.update()` once per loop and `delay()` many times per loop (and `delay()` is supposed to let background tasks run - apparently MDNS is not one of those). Splitting the main loop to alternate between two 1-seconds segments fixed the issue. So `MDNS.update()` shouldn't be left uncalled for more than a second or so. But this is probably specific to the timeout value of the mDNS resolver; for me that was Avahi.